### PR TITLE
Add return type

### DIFF
--- a/src/hooks/useOnClickOutside/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside/useOnClickOutside.ts
@@ -5,7 +5,7 @@ type AnyEvent = MouseEvent | TouchEvent
 function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   ref: RefObject<T>,
   handler: (event: AnyEvent) => void,
-) {
+): void {
   useEffect(() => {
     const listener = (event: AnyEvent) => {
       const el = ref?.current


### PR DESCRIPTION
I think we should add a return type to this function so that the warning in typescript-eslint does not appear.

https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md
Warning message: "ESLint: Missing return type on function.(@typescript-eslint/explicit-module-boundary-types)"