### PR TITLE
Slightly better wording for `useCopyToClipboard`

### DIFF
--- a/packages/frontend/src/hooks-doc/useCopyToClipboard/useCopyToClipboard.mdx
+++ b/packages/frontend/src/hooks-doc/useCopyToClipboard/useCopyToClipboard.mdx
@@ -3,6 +3,6 @@ title: useCopyToClipboard
 date: '2021-08-04'
 ---
 
-This React hook give you a `copy` method to save a string in the [clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard) and the copied value (default: `null`).
+This React hook provides a `copy` method to save a string in the [clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard) and the copied value (default: `null`).
 
 If anything doesn't work, it prints a warning in the console and the value will be `null`.


### PR DESCRIPTION
This could also have just been changed to "gives you" but "provides" feels nicer?